### PR TITLE
remove ISR for shows and individual photos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tsconfig.tsbuildinfo
 cypress/videos/
 cypress/screenshots/
 cypress/reports
+cypress/logs/
 
 # `next export` out directory
 /out

--- a/cypress/integration/continuous-integration/02 nav/photo-navigation.test.js
+++ b/cypress/integration/continuous-integration/02 nav/photo-navigation.test.js
@@ -1,6 +1,8 @@
 import dayjs from "dayjs";
 
 it("Navigates properly from photo to photo on the large photo pages", () => {
+  cy.resetDbAndIsrCache();
+  cy.reloadForISR();
   cy.visit("/photos");
 
   // click on the first photo

--- a/package-lock.json
+++ b/package-lock.json
@@ -4344,9 +4344,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001352",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
-      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -19383,9 +19383,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001352",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
-      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA=="
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
     },
     "caseless": {
       "version": "0.12.0",

--- a/src/__mocks__/mockData.ts
+++ b/src/__mocks__/mockData.ts
@@ -76,6 +76,79 @@ export const mockOnlyPastShows: Array<ShowWithVenue> = [
   },
 ];
 
+export const mockManyPastShows: Array<ShowWithVenue> = [
+  {
+    id: 2,
+    performAt: yesterday,
+    venueId: 2,
+    url: "http://venue.com/show",
+    venue: mockVenues[1],
+  },
+  {
+    id: 3,
+    performAt: dayjs("2021-01-01").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 4,
+    performAt: dayjs("2021-01-02").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 5,
+    performAt: dayjs("2021-01-03").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 6,
+    performAt: dayjs("2021-01-04").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 7,
+    performAt: dayjs("2021-01-05").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 8,
+    performAt: dayjs("2021-01-06").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 9,
+    performAt: dayjs("2021-01-07").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 10,
+    performAt: dayjs("2021-01-08").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+  {
+    id: 11,
+    performAt: dayjs("2021-01-09").toDate(),
+    venueId: 2,
+    url: null,
+    venue: mockVenues[1],
+  },
+];
+
 export const mockManyFutureShows = [
   {
     id: 1,

--- a/src/__tests__/api/jest.setup.ts
+++ b/src/__tests__/api/jest.setup.ts
@@ -10,15 +10,54 @@ import "@testing-library/jest-dom/extend-expect";
 // eslint-disable-next-line no-unused-vars
 import { describe, expect, test } from "@jest/globals";
 
-import { resetDB } from './prisma/reset-db'
+import { server } from "../../__mocks__/msw/server";
 
-beforeAll(async () => {
-  // seed db
-  await resetDB();
+// mock supabase methods
+// can't mock from test files: https://github.com/facebook/jest/issues/335
+// (mocked module must be called directly from file imported by test file)
+jest.mock("@/lib/supabase/utils", () =>
+  jest.requireActual("@/__mocks__/modules/supabase/utils"),
+);
+jest.mock("@/lib/supabase/hooks/useSupabasePhoto", () =>
+  jest.requireActual("@/__mocks__/modules/supabase/useSupabasePhoto"),
+);
+
+// issues with Link causing "not wrapped in act" errors
+// https://github.com/vercel/next.js/issues/20048#issuecomment-813426025
+jest.mock("next/link", () =>
+  jest.requireActual("@/__mocks__/modules/next/Link"),
+);
+
+// mocking returned user
+jest.mock("@/lib/auth/useWhitelistUser", () => ({
+  __esModule: true,
+  useWhitelistUser: jest.fn().mockReturnValue({ user: undefined }),
+}));
+
+// swallow twind / tailwindcss warnings
+// TODO: is there a more legit way to suppress these?
+// eslint-disable-next-line no-console
+console.warn = (warning) => {
+  if (!warning.match(/\[UNKNOWN_(DIRECTIVE|THEME_VALUE)\]/))
+    // eslint-disable-next-line no-console
+    console.log("WARNING:", warning);
+};
+
+beforeAll(() => {
+  // msw: Establish API mocking before all tests.
+  server.listen();
+
+  // reset mocks
+  jest.resetModules();
 });
 
-afterEach(async () => {
-  // reset and seed db
-  await resetDB();
+afterEach(() => {
+  // msw: Reset any request handlers that we may add during the tests,
+  // so they don't affect other tests.
+  server.resetHandlers();
 });
 
+afterAll(() => {
+  // msw: Clean up after the tests are finished.
+  server.close();
+});

--- a/src/__tests__/api/jest.setup.ts
+++ b/src/__tests__/api/jest.setup.ts
@@ -10,54 +10,16 @@ import "@testing-library/jest-dom/extend-expect";
 // eslint-disable-next-line no-unused-vars
 import { describe, expect, test } from "@jest/globals";
 
-import { server } from "../../__mocks__/msw/server";
+import { resetDB } from "./prisma/reset-db";
 
-// mock supabase methods
-// can't mock from test files: https://github.com/facebook/jest/issues/335
-// (mocked module must be called directly from file imported by test file)
-jest.mock("@/lib/supabase/utils", () =>
-  jest.requireActual("@/__mocks__/modules/supabase/utils"),
-);
-jest.mock("@/lib/supabase/hooks/useSupabasePhoto", () =>
-  jest.requireActual("@/__mocks__/modules/supabase/useSupabasePhoto"),
-);
-
-// issues with Link causing "not wrapped in act" errors
-// https://github.com/vercel/next.js/issues/20048#issuecomment-813426025
-jest.mock("next/link", () =>
-  jest.requireActual("@/__mocks__/modules/next/Link"),
-);
-
-// mocking returned user
-jest.mock("@/lib/auth/useWhitelistUser", () => ({
-  __esModule: true,
-  useWhitelistUser: jest.fn().mockReturnValue({ user: undefined }),
-}));
-
-// swallow twind / tailwindcss warnings
-// TODO: is there a more legit way to suppress these?
-// eslint-disable-next-line no-console
-console.warn = (warning) => {
-  if (!warning.match(/\[UNKNOWN_(DIRECTIVE|THEME_VALUE)\]/))
-    // eslint-disable-next-line no-console
-    console.log("WARNING:", warning);
-};
-
-beforeAll(() => {
-  // msw: Establish API mocking before all tests.
-  server.listen();
-
-  // reset mocks
-  jest.resetModules();
+beforeAll(async () => {
+  // seed db
+  await resetDB();
 });
 
-afterEach(() => {
-  // msw: Reset any request handlers that we may add during the tests,
-  // so they don't affect other tests.
-  server.resetHandlers();
+afterEach(async () => {
+  // reset and seed db
+  await resetDB();
 });
 
-afterAll(() => {
-  // msw: Clean up after the tests are finished.
-  server.close();
-});
+afterAll(async () => {});

--- a/src/__tests__/api/tests/get.test.ts
+++ b/src/__tests__/api/tests/get.test.ts
@@ -11,7 +11,7 @@ import photoHandler from "@/pages/api/photos";
 import showHandler from "@/pages/api/shows";
 import venueHandler from "@/pages/api/venues";
 
-import { nextMonth, resetDB, tomorrow, yesterday } from "../prisma/reset-db";
+import { nextMonth, tomorrow, yesterday } from "../prisma/reset-db";
 
 // ------------------------------------------------------------------ //
 // EXPECTED GET DATA

--- a/src/__tests__/api/tests/get.test.ts
+++ b/src/__tests__/api/tests/get.test.ts
@@ -11,7 +11,7 @@ import photoHandler from "@/pages/api/photos";
 import showHandler from "@/pages/api/shows";
 import venueHandler from "@/pages/api/venues";
 
-import { nextMonth, tomorrow, yesterday } from "../prisma/reset-db";
+import { nextMonth, resetDB, tomorrow, yesterday } from "../prisma/reset-db";
 
 // ------------------------------------------------------------------ //
 // EXPECTED GET DATA

--- a/src/__tests__/api/tests/revalidationAuth.test.ts
+++ b/src/__tests__/api/tests/revalidationAuth.test.ts
@@ -1,11 +1,10 @@
 import { testApiHandler } from "next-test-api-route-handler";
 
-import showIdHandler from "@/pages/api/shows/[id]";
-import showsHandler from "@/pages/api/shows/index";
+import photosHandler from "@/pages/api/photos/index";
 
-test("PUT /api/shows returns 401 status for incorrect revalidation secret", async () => {
+test("PUT /api/photos returns 401 status for incorrect revalidation secret", async () => {
   await testApiHandler({
-    handler: showsHandler,
+    handler: photosHandler,
     paramsPatcher: (params) => {
       params.queryStringURLParams = { secret: "NOT THE REAL SECRET" };
     },
@@ -16,35 +15,9 @@ test("PUT /api/shows returns 401 status for incorrect revalidation secret", asyn
   });
 });
 
-test("PATCH /api/shows/:id returns 401 status for incorrect revalidation secret", async () => {
+test("GET /api/photos DOES NOT return 401 status for missing revalidation secret", async () => {
   await testApiHandler({
-    handler: showIdHandler,
-    paramsPatcher: (params) => {
-      params.queryStringURLParams = { secret: "NOT THE REAL SECRET" };
-    },
-    test: async ({ fetch }) => {
-      const res = await fetch({ method: "PATCH" });
-      expect(res.status).toEqual(401);
-    },
-  });
-});
-
-test("DELETE /api/shows/:id returns 401 status for incorrect revalidation secret", async () => {
-  await testApiHandler({
-    handler: showIdHandler,
-    paramsPatcher: (params) => {
-      params.queryStringURLParams = { secret: "NOT THE REAL SECRET" };
-    },
-    test: async ({ fetch }) => {
-      const res = await fetch({ method: "DELETE" });
-      expect(res.status).toEqual(401);
-    },
-  });
-});
-
-test("GET /api/shows/:id DOES NOT return 401 status for missing revalidation secret", async () => {
-  await testApiHandler({
-    handler: showsHandler,
+    handler: photosHandler,
     test: async ({ fetch }) => {
       const res = await fetch({ method: "GET" });
       expect(res.status).toEqual(200);

--- a/src/lib/api/constants.ts
+++ b/src/lib/api/constants.ts
@@ -1,8 +1,8 @@
 export const uploadDestination = "public/uploads";
 
 export const revalidationRoutes = {
-  shows: ["/shows", "/"],
-  venues: ["/shows"],
+  shows: [],
+  venues: [],
   musicians: ["/band"],
   instruments: ["/band"],
   photos: ["/photos", "/"],

--- a/src/lib/photos/hooks/usePhotos.tsx
+++ b/src/lib/photos/hooks/usePhotos.tsx
@@ -1,17 +1,37 @@
-import { UseMutateFunction, useMutation } from "react-query";
+import dayjs from "dayjs";
+import { useMemo } from "react";
+import {
+  UseMutateFunction,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "react-query";
 
 import { useToast } from "@/components/toasts/useToast";
 import {
   addUploadedPhoto,
   deletePhoto,
+  fetchPhotos,
+  getPhotoDate,
   patchPhoto,
   PhotoResponse,
 } from "@/lib/photos";
-import { PhotoPatchArgs, UploadedPhotoFormData } from "@/lib/photos/types";
+import {
+  PhotoPatchArgs,
+  PhotoWithShowAndVenue,
+  UploadedPhotoFormData,
+} from "@/lib/photos/types";
 import { queryKeys } from "@/lib/react-query/query-keys";
 import { useHandleError } from "@/lib/react-query/useHandleError";
 
+export type NextAndPrev = {
+  next: number | null;
+  prev: number | null;
+};
+export type NextAndPrevObject = Record<number, NextAndPrev>;
+
 type UsePhotosReturnValue = {
+  photos: Array<PhotoWithShowAndVenue>;
   addUploadedPhoto: UseMutateFunction<
     PhotoResponse,
     unknown,
@@ -25,17 +45,53 @@ type UsePhotosReturnValue = {
     PhotoPatchArgs,
     unknown
   >;
+  nextAndPrevIndexes: NextAndPrevObject;
 };
+
+const sortPhotos = (photos: Array<PhotoWithShowAndVenue>) =>
+  photos.sort((a, b) => {
+    const photoDateA = dayjs(getPhotoDate(a)).unix();
+    const photoDateB = dayjs(getPhotoDate(b)).unix();
+    if (photoDateA === photoDateB) {
+      // Filename is only important when dates are the same
+      return a.imagePath.localeCompare(b.imagePath);
+    }
+    return photoDateA < photoDateB ? 1 : -1;
+  });
 
 export const usePhotos = (): UsePhotosReturnValue => {
   const { showToast } = useToast();
-  const { handleMutateError } = useHandleError();
+  const { handleQueryError, handleMutateError } = useHandleError();
+  const { data: photos = [] } = useQuery<Array<PhotoWithShowAndVenue>>(
+    queryKeys.photos,
+    ({ signal }) => fetchPhotos(signal),
+    {
+      onError: handleQueryError,
+      select: sortPhotos,
+    },
+  );
+
+  const nextAndPrevIndexes = useMemo(() => {
+    const tempNextAndPrev: NextAndPrevObject = [];
+    photos.forEach((photo, index) => {
+      tempNextAndPrev[photo.id] = {
+        next: photos[index + 1] ? photos[index + 1].id : null,
+        prev: photos[index - 1] ? photos[index - 1].id : null,
+      };
+    });
+    return tempNextAndPrev;
+  }, [photos]);
+
+  const queryClient = useQueryClient();
+  const invalidatePhotos = () =>
+    queryClient.invalidateQueries([queryKeys.photos]);
 
   const { mutate: addUploadedPhotoMutate } = useMutation(
     queryKeys.photos,
     addUploadedPhoto,
     {
       onSuccess: () => {
+        invalidatePhotos();
         showToast("success", "You have added a photo");
       },
       onError: (error) => handleMutateError(error, "add photo"),
@@ -47,6 +103,7 @@ export const usePhotos = (): UsePhotosReturnValue => {
     deletePhoto,
     {
       onSuccess: () => {
+        invalidatePhotos();
         showToast("success", `You have deleted the photo`);
       },
       onError: (error) => handleMutateError(error, "delete photo"),
@@ -55,14 +112,17 @@ export const usePhotos = (): UsePhotosReturnValue => {
 
   const { mutate: updatePhoto } = useMutation(queryKeys.photos, patchPhoto, {
     onSuccess: () => {
+      invalidatePhotos();
       showToast("success", "You have updated the photo");
     },
     onError: (error) => handleMutateError(error, "update photo"),
   });
 
   return {
+    photos,
     addUploadedPhoto: addUploadedPhotoMutate,
     updatePhoto,
     deletePhoto: deletePhotoMutate,
+    nextAndPrevIndexes,
   };
 };

--- a/src/lib/shows/components/venues/EditVenues.tsx
+++ b/src/lib/shows/components/venues/EditVenues.tsx
@@ -3,21 +3,24 @@ import { tw } from "twind";
 
 import { Heading } from "@/components/lib/Style/Heading";
 import { Section } from "@/components/lib/Style/Section";
+import { useVenues } from "@/lib/shows/hooks/useVenues";
 import { VenueWithShowCount } from "@/lib/venues/types";
 
 import { AddVenueModal } from "./EditVenueModal";
 import { Venue } from "./Venue";
 
-export const EditVenues: React.FC<{ venues: Array<VenueWithShowCount> }> = ({
-  venues,
-}) => (
-  <Section className={tw(["text-center"])}>
-    <Heading>Venues</Heading>
-    <AddVenueModal />
-    {venues
-      .sort((a, b) => (a.name > b.name ? 1 : -1))
-      .map((venue: VenueWithShowCount) => (
-        <Venue key={venue.id} venue={venue} />
-      ))}
-  </Section>
-);
+export const EditVenues: React.FC = () => {
+  const { venues } = useVenues();
+
+  return (
+    <Section className={tw(["text-center"])}>
+      <Heading>Venues</Heading>
+      <AddVenueModal />
+      {venues
+        .sort((a, b) => (a.name > b.name ? 1 : -1))
+        .map((venue: VenueWithShowCount) => (
+          <Venue key={venue.id} venue={venue} />
+        ))}
+    </Section>
+  );
+};

--- a/src/pages/api/photos/[id].ts
+++ b/src/pages/api/photos/[id].ts
@@ -20,9 +20,7 @@ addStandardGetById({
 addStandardPatch({
   handler,
   patchFunc: patchPhoto,
-  // TODO: this should redo all photo IDs, since order might change if date changes
-  // https://github.com/vercel/next.js/discussions/34585
-  revalidationRoutes: [...revalidationRoutes.photos, "/photos/:id"],
+  revalidationRoutes: revalidationRoutes.photos,
 });
 
 export default handler;

--- a/src/pages/api/revalidate/index.ts
+++ b/src/pages/api/revalidate/index.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { createHandler } from "@/lib/api/handler";
 
-const revalidationRoutes = ["/", "/shows", "/photos", "/band"];
+const revalidationRoutes = ["/", "/photos", "/band"];
 
 const handler = createHandler();
 handler.get(async (req: NextApiRequest, res: NextApiResponse) => {

--- a/src/pages/api/shows/[id].ts
+++ b/src/pages/api/shows/[id].ts
@@ -10,7 +10,7 @@ const handler = createHandler(revalidationRoutes.shows);
 addStandardDelete({
   handler,
   deleteFunc: deleteShow,
-  revalidationRoutes: ["/shows"],
+  revalidationRoutes: [],
 });
 
 addStandardPatch({

--- a/src/pages/photos/[id].tsx
+++ b/src/pages/photos/[id].tsx
@@ -2,6 +2,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import dayjs from "dayjs";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import React from "react";
 import { IconType } from "react-icons";
 import { CgSpinner } from "react-icons/cg";
@@ -15,7 +16,8 @@ import { getPhotoDate } from "@/lib/photos";
 import { DeletePhotoModal } from "@/lib/photos/components/DeletePhotoModal";
 import { EditPhotoModal } from "@/lib/photos/components/EditPhotoModal";
 import { getNextAndPrevIndexes } from "@/lib/photos/dataManipulation";
-import { NextAndPrev, PhotoWithShowAndVenue } from "@/lib/photos/types";
+import { usePhoto } from "@/lib/photos/hooks/usePhoto";
+import { usePhotos } from "@/lib/photos/hooks/usePhotos";
 import { getPhotoById, getPhotos } from "@/lib/prisma/queries/photos";
 import { UPLOADS_BUCKET } from "@/lib/supabase/constants";
 import { useSupabasePhoto } from "@/lib/supabase/hooks/useSupabasePhoto";
@@ -74,14 +76,13 @@ const AdvanceButton: React.FC<{
     </button>
   );
 
-const Photo: React.FC<{
-  photoJSON: string;
-  nextAndPrevIndexes: NextAndPrev;
-}> = ({ photoJSON, nextAndPrevIndexes }) => {
-  const photo: PhotoWithShowAndVenue = JSON.parse(photoJSON);
+const Photo: React.FC = () => {
   const { user } = useWhitelistUser();
-
-  const { next: nextIndex, prev: prevIndex } = nextAndPrevIndexes;
+  const router = useRouter();
+  const { id } = router.query;
+  const photoId = Number(id);
+  const { photo } = usePhoto({ photoId });
+  const { nextAndPrevIndexes } = usePhotos();
 
   const { imgSrc } = useSupabasePhoto(photo?.imagePath ?? null, UPLOADS_BUCKET);
 
@@ -89,6 +90,17 @@ const Photo: React.FC<{
   // contains the [id] from the previous route, which leads to the wrong image
   // showing for half a second or so (without this check)
   const imageSrcMatches = imgSrc && photo && imgSrc.search(photo.imagePath) > 0;
+
+  if (Number.isNaN(photoId)) {
+    return <Heading>Photo not found</Heading>;
+  }
+
+  let nextIndex;
+  let prevIndex;
+  if (nextAndPrevIndexes[photoId]) {
+    nextIndex = nextAndPrevIndexes[photoId].next;
+    prevIndex = nextAndPrevIndexes[photoId].prev;
+  }
 
   const photoDate = photo ? getPhotoDate(photo) : undefined;
 


### PR DESCRIPTION
- interval ISR didn't work in conjunction with on-demand ISR for shows, so past shows weren't rolling off the "upcoming shows list"
- individual photos weren't updating when new photos were added, so the "next" arrow for the photo that was previously last was missing after uploading new photos
- also restricted the "recent shows" to 5, with an option to show all